### PR TITLE
Fixing defaults when no mainnet flag is set

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -11,7 +11,11 @@ export const UriPrefix = '/';
 export const TitleDefault = 'Aleph Zero Staking Dashboard';
 export const DappName = 'Aleph Zero Staking Dashboard';
 export const PolkadotUrl = 'https://alephzero.org/staking/';
-export const DefaultNetwork = 'alephzero';
+export const DefaultNetwork =
+  process.env.NODE_ENV === 'production' &&
+  process.env.REACT_APP_DISABLE_MAINNET !== '1'
+    ? 'alephzero'
+    : 'alephzerotestnet';
 
 /*
  * Data Structure Helpers


### PR DESCRIPTION
The default network should be set to mainnet only if it's production build and the mainnet is avaliable.
There are 3 places where the default is set, this one seems the last one that I missed before.

Setup:
`REACT_APP_DISABLE_MAINNET=1` and production build.