### PR TITLE
Fix BN bug in an unbonding modal

### DIFF
--- a/src/modals/UnlockChunks/Overview.tsx
+++ b/src/modals/UnlockChunks/Overview.tsx
@@ -87,7 +87,7 @@ export const Overview = forwardRef(
           </StatWrapper>
         </StatsWrapper>
 
-        {withdrawAvailable.toNumber() > 0 && (
+        {withdrawAvailable.gt(new BN('0')) && (
           <div style={{ margin: '1rem 0 0.5rem 0' }}>
             <ButtonSubmit
               text="Withdraw Unlocked"


### PR DESCRIPTION
Fixed a bug where converting BN to number caused an exception. It happened in the Unbonding modal, when you unbonded a large enough sum and tried to claim it.