### PR TITLE
Removed duplicate staking info and typo in tips

### DIFF
--- a/src/locale/en/tips.json
+++ b/src/locale/en/tips.json
@@ -15,7 +15,7 @@
     },
     "connect_extensions": [
       "Connect Extensions",
-      "Connect your accounts to begin using thestaking dashboard.",
+      "Connect your accounts to begin using the staking dashboard.",
       [
         "Connect your accounts to begin using the staking dashboard.",
         "Accounts are accessed via web extensions, that act as wallets. Your wallet is used to sign transactions that you submit within the dashboard.",

--- a/src/pages/Overview/NetworkSats/Inflation.tsx
+++ b/src/pages/Overview/NetworkSats/Inflation.tsx
@@ -59,15 +59,6 @@ export const Inflation = () => {
               </h4>
             </div>
           </div>
-          <div>
-            <div className="inner">
-              <h2>{toFixedIfNecessary(supplyAsPercent, 2)}%</h2>
-              <h4>
-                {t('overview.supply_staked')}{' '}
-                <OpenHelpIcon helpKey="Supply Staked" />
-              </h4>
-            </div>
-          </div>
         </div>
       </section>
     </InflationWrapper>

--- a/src/pages/Overview/NetworkSats/Inflation.tsx
+++ b/src/pages/Overview/NetworkSats/Inflation.tsx
@@ -1,32 +1,19 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { useApi } from 'contexts/Api';
 import { useNetworkMetrics } from 'contexts/Network';
-import { useStaking } from 'contexts/Staking';
 import useInflation from 'library/Hooks/useInflation';
 import { OpenHelpIcon } from 'library/OpenHelpIcon';
 import { useTranslation } from 'react-i18next';
-import { planckBnToUnit, toFixedIfNecessary } from 'Utils';
+import { toFixedIfNecessary } from 'Utils';
 import { InflationWrapper } from './Wrappers';
 
 export const Inflation = () => {
-  const { units } = useApi().network;
   const { metrics } = useNetworkMetrics();
-  const { staking } = useStaking();
   const { inflation, stakedReturn } = useInflation();
   const { t } = useTranslation('pages');
 
-  const { lastTotalStake } = staking;
   const { totalIssuance } = metrics;
-
-  // total supply as percent
-  const totalIssuanceBase = planckBnToUnit(totalIssuance, units);
-  const lastTotalStakeBase = planckBnToUnit(lastTotalStake, units);
-  const supplyAsPercent =
-    lastTotalStakeBase === 0
-      ? 0
-      : lastTotalStakeBase / (totalIssuanceBase * 0.01);
 
   return (
     <InflationWrapper>


### PR DESCRIPTION
- Removed duplicate `staking supply %` info in network stats panel on the overviews page
- Fixed one typo in tips