### PR TITLE
A0: Increase font size throughout the application

### DIFF
--- a/src/Wrappers.tsx
+++ b/src/Wrappers.tsx
@@ -146,19 +146,15 @@ export const SideInterfaceWrapper = styled.div<SideInterfaceWrapperProps>`
   flex: 0;
   overflow: hidden;
   min-width: ${(props) =>
-    props.minimised
-      ? `${SideMenuMinimisedWidth}px`
-      : `${SideMenuMaximisedWidth}px`};
+    props.minimised ? SideMenuMinimisedWidth : SideMenuMaximisedWidth};
   max-width: ${(props) =>
-    props.minimised
-      ? `${SideMenuMinimisedWidth}px`
-      : `${SideMenuMaximisedWidth}px`};
+    props.minimised ? SideMenuMinimisedWidth : SideMenuMaximisedWidth};
   transition: all 0.5s cubic-bezier(0.1, 1, 0.2, 1);
 
   @media (max-width: ${SideMenuStickyThreshold}px) {
     position: fixed;
     top: 0;
-    left: ${(props) => (props.open ? 0 : `-${SideMenuMaximisedWidth}px`)};
+    left: ${(props) => (props.open ? 0 : `-${SideMenuMaximisedWidth}`)};
   }
 `;
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -40,8 +40,8 @@ export const PayeeStatus = [
 ];
 
 export const InterfaceMaximumWidth = 1550;
-export const SideMenuMaximisedWidth = 185;
-export const SideMenuMinimisedWidth = 75;
+export const SideMenuMaximisedWidth = '16rem';
+export const SideMenuMinimisedWidth = '90px';
 export const SideMenuStickyThreshold = 1175;
 export const SectionFullWidthThreshold = 1050;
 export const ShowAccountsButtonWidthThreshold = 850;

--- a/src/index.css
+++ b/src/index.css
@@ -17,18 +17,18 @@
 
 /* global font size */
 html {
-  font-size: 10px;
+  font-size: 12px;
 }
 
 @media (min-width: 600px) {
   html {
-    font-size: 11.2px;
+    font-size: 14px;
   }
 }
 
 @media (min-width: 1600px) {
   html {
-    font-size: 11.7px;
+    font-size: 16px;
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -17,18 +17,18 @@
 
 /* global font size */
 html {
-  font-size: 12px;
+  font-size: 11px;
 }
 
 @media (min-width: 600px) {
   html {
-    font-size: 14px;
+    font-size: 12px;
   }
 }
 
 @media (min-width: 1600px) {
   html {
-    font-size: 16px;
+    font-size: 13px;
   }
 }
 

--- a/src/library/Graphs/Bonded.tsx
+++ b/src/library/Graphs/Bonded.tsx
@@ -108,16 +108,7 @@ export const Bonded = ({
       noMargin
       style={{ border: 'none', boxShadow: 'none' }}
     >
-      <div
-        className="graph"
-        style={{
-          flex: 0,
-          paddingRight: '1rem',
-          height: 160,
-        }}
-      >
-        <Doughnut options={options} data={data} />
-      </div>
+      <Doughnut options={options} data={data} />
     </GraphWrapper>
   );
 };

--- a/src/library/SideMenu/Heading/Wrapper.tsx
+++ b/src/library/SideMenu/Heading/Wrapper.tsx
@@ -13,7 +13,7 @@ export const Wrapper = styled.div<{ minimised: number }>`
 
   h5 {
     color: ${textSecondary};
-    margin: 0; /* Overrides the global h5 style */
+    margin: 0.5rem 0; /* Overrides the global h5 style */
     padding: 0 0.5rem;
     opacity: 0.7;
   }

--- a/src/library/SideMenu/Heading/Wrapper.tsx
+++ b/src/library/SideMenu/Heading/Wrapper.tsx
@@ -13,7 +13,7 @@ export const Wrapper = styled.div<{ minimised: number }>`
 
   h5 {
     color: ${textSecondary};
-    margin: 1.1rem 0 0.3rem 0;
+    margin: 0; /* Overrides the global h5 style */
     padding: 0 0.5rem;
     opacity: 0.7;
   }

--- a/src/library/SideMenu/Primary/Wrappers.tsx
+++ b/src/library/SideMenu/Primary/Wrappers.tsx
@@ -94,7 +94,7 @@ export const MinimisedWrapper = styled(motion.div)`
   justify-content: center;
   align-items: center;
   padding: 0.65rem 0rem;
-  margin: 0.7rem 0.2rem 0.5rem 0;
+  margin: 0.2rem 0 0.2rem 0;
   font-size: 1.1rem;
   position: relative;
   border: 1px solid rgba(255, 255, 255, 0);

--- a/src/library/SideMenu/Wrapper.ts
+++ b/src/library/SideMenu/Wrapper.ts
@@ -26,9 +26,7 @@ export const Wrapper = styled.div<MinimisedProps>`
   flex-flow: column nowrap;
   backdrop-filter: blur(4px);
   width: ${(props) =>
-    props.minimised
-      ? `${SideMenuMinimisedWidth}px`
-      : `${SideMenuMaximisedWidth}px`};
+    props.minimised ? SideMenuMinimisedWidth : SideMenuMaximisedWidth};
 
   @media (max-width: ${SideMenuStickyThreshold}px) {
     background: ${backgroundOverlay};


### PR DESCRIPTION
Original _issue_:
> That's right, the font might be better raised a little. because it's too small to read (suggested 125 or 140%) – a few users mentioned the font

---

I wasn't sure if the above comment related to the entire app or just some selected parts, but I reckoned that the dashboard would benefit from a generic font size increase, so that's what I ended up with.

This: [`src/index.css`](https://github.com/Cardinal-Cryptography/polkadot-staking-dashboard/pull/14/files#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09e) is the main change. The rest is an adaption of elements to the increased font size, mainly in the menu pane.

<details>
<summary>~Visual comparison of the effects~ _the font size has been changed since to a slightly smaller, so the comparison is no longer relevant_</summary>

|| Original | Updated |
|-|-|-|
| Full size | ![full_size_original](https://user-images.githubusercontent.com/6209244/216202900-a9292106-52ac-4b01-bda7-4838016ca13c.png) | ![full_size_updated](https://user-images.githubusercontent.com/6209244/216202898-dbaa0513-2ac6-4cde-8587-21843f9fa88f.png)
| Smaller size | ![smaller_size_updated](https://user-images.githubusercontent.com/6209244/216202892-1a22eed5-00de-4e2e-aaf7-2719ac9621fe.png) | ![smaller_size_original](https://user-images.githubusercontent.com/6209244/216202895-ebf54198-4fd3-4fd6-ba0e-4df472f5cfa8.png)
| Mobile size | ![mobile_size_original](https://user-images.githubusercontent.com/6209244/216202890-00772bf5-d605-4896-9a92-57f008aecda2.png) | ![mobile_size_updated](https://user-images.githubusercontent.com/6209244/216202891-639e192f-5c69-4e2a-aa8d-1b7786cf6eae.png)
| Collapsed menu | ![collapsed_menu_original](https://user-images.githubusercontent.com/6209244/216202879-ea7df273-52ea-4522-ba42-b111d70f4f43.png) | ![collapsed_menu_updated](https://user-images.githubusercontent.com/6209244/216202889-ba35914f-7448-4b1b-933c-20e1d9c8abe6.png)
</details>