### PR TITLE
A0-2035: Skip binance requests upon a dedicated env var value

### DIFF
--- a/src/library/Hooks/usePrices/index.tsx
+++ b/src/library/Hooks/usePrices/index.tsx
@@ -52,20 +52,24 @@ export const usePrices = () => {
 
   // initial price subscribe
   useEffect(() => {
-    initiatePriceInterval();
-    return () => {
-      if (priceHandle !== null) {
-        clearInterval(priceHandle);
+    if (services.includes('binance_spot')) {
+      if (priceHandle === null) {
+        initiatePriceInterval();
       }
-    };
+    } else if (priceHandle !== null) {
+      clearInterval(priceHandle);
+    }
   }, []);
 
   // resubscribe on network toggle
   useEffect(() => {
-    if (priceHandle !== null) {
+    if (services.includes('binance_spot')) {
+      if (priceHandle === null) {
+        initiatePriceInterval();
+      }
+    } else if (priceHandle !== null) {
       clearInterval(priceHandle);
     }
-    initiatePriceInterval();
   }, [network]);
 
   // servie toggle

--- a/src/library/Hooks/usePrices/index.tsx
+++ b/src/library/Hooks/usePrices/index.tsx
@@ -50,26 +50,11 @@ export const usePrices = () => {
     }, 1000 * 30);
   };
 
-  // initial price subscribe
+  // subscribe to price
   useEffect(() => {
-    if (services.includes('binance_spot')) {
-      if (priceHandle === null) {
-        initiatePriceInterval();
-      }
-    } else if (priceHandle !== null) {
-      clearInterval(priceHandle);
-    }
-  }, []);
+    if (services.includes('binance_spot')) initiatePriceInterval();
 
-  // resubscribe on network toggle
-  useEffect(() => {
-    if (services.includes('binance_spot')) {
-      if (priceHandle === null) {
-        initiatePriceInterval();
-      }
-    } else if (priceHandle !== null) {
-      clearInterval(priceHandle);
-    }
+    return () => clearInterval(priceHandle);
   }, [network]);
 
   // servie toggle


### PR DESCRIPTION
Review with [&w=1](https://github.com/Cardinal-Cryptography/polkadot-staking-dashboard/pull/21/files?diff=split&w=1).

We are already setting an env var disabling binance requests in [here](https://github.com/Cardinal-Cryptography/polkadot-staking-dashboard/blob/7eb022fb8789b5946151ba6f961650ec902d73e1/.github/workflows/build-and-deploy-to-mainnet.yaml#L21), but it was not respected in all the places in code so this PR fixes that part.